### PR TITLE
Centered the favicon position

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const favicon = Astro.props.favicon ? Astro.props.favicon : "🌍";
 		<meta name="viewport" content="width=device-width" />
 		<link
       rel="icon"
-      href=`data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${favicon}</text></svg>` />
+      href=`data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text x=%2250%25%22 y=%220.95em%22 text-anchor=%22middle%22 font-size=%2290px%22>${favicon}</text></svg>` />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 	</head>


### PR DESCRIPTION
Made the favicon position more centered but more importantly, no longer get clipped.
I tried not to magic number it using the "dominant-baseline" property but none of the options would perfectly center it, so its been magic numbered.